### PR TITLE
Support JSON-encoded list values in CLI args

### DIFF
--- a/src/pydantic_config/cli.py
+++ b/src/pydantic_config/cli.py
@@ -430,15 +430,29 @@ def _find_optional_model_paths(cls: type, prefix: str = "") -> set[str]:
     return paths
 
 
-def _is_dict_field(annotation: type) -> bool:
-    """Check if annotation is a dict type (bare ``dict`` or ``dict[str, Any]``)."""
+_JSON_VALUE_TYPES = (dict, list)
+
+
+def _is_json_value_field(annotation: type) -> bool:
+    """Check if annotation is a type that should accept JSON-encoded CLI values.
+
+    Covers ``dict``, ``list``, and their ``Optional`` / ``Annotated`` wrappers.
+    """
     if hasattr(annotation, "__metadata__"):
         annotation = get_args(annotation)[0]
-    return annotation is dict or get_origin(annotation) is dict
+    origin = get_origin(annotation)
+    if annotation in _JSON_VALUE_TYPES or origin in _JSON_VALUE_TYPES:
+        return True
+    if origin is Union or origin is getattr(types, "UnionType", None):
+        non_none = [a for a in get_args(annotation) if a is not type(None)]
+        if len(non_none) == 1:
+            inner = non_none[0]
+            return inner in _JSON_VALUE_TYPES or get_origin(inner) in _JSON_VALUE_TYPES
+    return False
 
 
-def _find_dict_field_paths(cls: type, prefix: str = "") -> set[str]:
-    """Recursively find all CLI arg paths (kebab-case) that map to dict fields."""
+def _find_json_value_field_paths(cls: type, prefix: str = "") -> set[str]:
+    """Recursively find all CLI arg paths (kebab-case) that map to JSON-value fields."""
     paths: set[str] = set()
     if not hasattr(cls, "model_fields"):
         return paths
@@ -446,21 +460,24 @@ def _find_dict_field_paths(cls: type, prefix: str = "") -> set[str]:
         field_kebab = field_name.replace("_", "-")
         full_path = f"{prefix}.{field_kebab}" if prefix else field_kebab
         annotation = field_info.annotation
-        if _is_dict_field(annotation):
+        if _is_json_value_field(annotation):
             paths.add(full_path)
         inner = annotation
         if hasattr(inner, "__metadata__"):
             inner = get_args(inner)[0]
         if isinstance(inner, type) and issubclass(inner, BaseModel):
-            paths.update(_find_dict_field_paths(inner, prefix=full_path))
+            paths.update(_find_json_value_field_paths(inner, prefix=full_path))
     return paths
 
 
-def _extract_json_dict_args(args: list[str], dict_paths: set[str]) -> tuple[list[str], dict]:
-    """Intercept CLI args for dict fields and parse their JSON values.
+def _extract_json_value_args(args: list[str], json_paths: set[str]) -> tuple[list[str], dict]:
+    """Intercept CLI args for dict/list fields and parse their JSON values.
 
-    When a CLI arg like ``--extra-kwargs '{"key": 123}'`` matches a known
-    dict field path, parse the JSON and inject it into the config dict.
+    Handles any CLI arg whose path maps to a dict or list field and whose
+    value looks like JSON (starts with ``{`` or ``[``).  For example::
+
+        --extra-kwargs '{"key": 123}'     → dict field
+        --buffer.env-ratios '[0.7, 0.3]'  → list field
 
     Returns (remaining_args, config_overrides_as_nested_dict).
     """
@@ -472,9 +489,8 @@ def _extract_json_dict_args(args: list[str], dict_paths: set[str]) -> tuple[list
         arg = args[i]
         if arg.startswith("--"):
             path = arg[2:]
-            if path in dict_paths and i + 1 < len(args):
-                value_str = args[i + 1]
-                parsed = json.loads(value_str)
+            if path in json_paths and i + 1 < len(args) and args[i + 1][:1] in ("{", "["):
+                parsed = json.loads(args[i + 1])
                 snake_path = path.replace("-", "_")
                 nested = _nest_config(snake_path, parsed)
                 overrides = _deep_merge(overrides, nested)
@@ -645,12 +661,13 @@ def cli(
             if bare_overrides:
                 merged_config = _deep_merge(merged_config, bare_overrides)
 
-        # Extract JSON dict args (e.g. --extra-kwargs '{"key": 123}')
-        dict_paths = _find_dict_field_paths(cls)
-        if dict_paths:
-            remaining_args, dict_overrides = _extract_json_dict_args(remaining_args, dict_paths)
-            if dict_overrides:
-                merged_config = _deep_merge(merged_config, dict_overrides)
+        # Extract JSON-encoded values for dict/list fields
+        # (e.g. --extra-kwargs '{"key": 123}', --env-ratios '[0.7, 0.3]')
+        json_paths = _find_json_value_field_paths(cls)
+        if json_paths:
+            remaining_args, json_overrides = _extract_json_value_args(remaining_args, json_paths)
+            if json_overrides:
+                merged_config = _deep_merge(merged_config, json_overrides)
 
         # Build default from merged config
         config_default = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -753,6 +753,92 @@ def test_dict_any_in_discriminated_union(tmp_toml_file):
     assert config.mode.kwargs == {"alpha": 0.5}
 
 
+# Tests: list fields via JSON CLI args
+
+
+def test_list_field_via_json_cli():
+    """--env-ratios '[0.7, 0.3]' should parse JSON and set the list field."""
+
+    class Config(BaseConfig):
+        env_ratios: list[float] = []
+        name: str = "test"
+
+    config = cli(Config, args=["--env-ratios", "[0.7, 0.3]", "--name", "hello"])
+    assert config.env_ratios == [0.7, 0.3]
+    assert config.name == "hello"
+
+
+def test_list_field_via_json_cli_nested():
+    """JSON list args should work for nested config fields."""
+
+    class BufferConfig(BaseConfig):
+        env_ratios: list[float] | None = None
+        seed: int | None = None
+
+    class Config(BaseConfig):
+        buffer: BufferConfig = BufferConfig()
+
+    config = cli(Config, args=["--buffer.env-ratios", "[0.7, 0.2, 0.1]"])
+    assert config.buffer.env_ratios == [0.7, 0.2, 0.1]
+
+
+def test_list_field_via_json_cli_optional():
+    """JSON list args should work for Optional[list[...]] fields."""
+
+    class Config(BaseConfig):
+        tags: list[str] | None = None
+        name: str = "test"
+
+    config = cli(Config, args=["--tags", '["alpha", "beta"]', "--name", "hello"])
+    assert config.tags == ["alpha", "beta"]
+
+
+def test_list_field_via_json_cli_integers():
+    """JSON list args should work for list[int] fields."""
+
+    class Config(BaseConfig):
+        gpu_ids: list[int] = []
+
+    config = cli(Config, args=["--gpu-ids", "[0, 1, 2, 3]"])
+    assert config.gpu_ids == [0, 1, 2, 3]
+
+
+def test_list_field_space_separated_still_works():
+    """Space-separated list args (tyro native) should still work when not JSON."""
+
+    class Config(BaseConfig):
+        env_ratios: list[float] = []
+
+    config = cli(Config, args=["--env-ratios", "0.7", "0.3"])
+    assert config.env_ratios == [0.7, 0.3]
+
+
+def test_list_field_via_json_cli_with_toml(tmp_toml_file):
+    """JSON list CLI args should override TOML list values."""
+
+    class BufferConfig(BaseConfig):
+        env_ratios: list[float] | None = None
+
+    class Config(BaseConfig):
+        buffer: BufferConfig = BufferConfig()
+        name: str = "test"
+
+    write_file(tmp_toml_file, 'name = "from-toml"\n\n[buffer]\nenv_ratios = [0.5, 0.5]')
+    config = cli(Config, args=["@", tmp_toml_file, "--buffer.env-ratios", "[0.7, 0.3]"])
+    assert config.buffer.env_ratios == [0.7, 0.3]
+    assert config.name == "from-toml"
+
+
+def test_list_field_via_toml_no_cli():
+    """list fields from TOML (no CLI override) should work as before."""
+
+    class Config(BaseConfig):
+        ratios: list[float] = []
+
+    config = cli(Config, args=[])
+    assert config.ratios == []
+
+
 # Tests: dict[str, Any] fields via JSON CLI args
 
 


### PR DESCRIPTION
JSON-encoded dict values on the CLI already work (e.g. `--extra-kwargs '{"key": 123}'`), but the same pattern breaks for list fields. Passing `--buffer.env-ratios '[0.7, 0.3]'` falls through to tyro, which expects space-separated values and fails to parse the JSON string.

This came up because the platform serializes list config values as JSON when building orchestrator CLI commands, and after the migration to pydantic_config those commands started failing silently.

Instead of adding a separate list-specific handler next to the dict one, this PR unifies them. The old `_is_dict_field` / `_find_dict_field_paths` / `_extract_json_dict_args` triple is replaced by a single generic version that covers both dict and list fields (and any future container type — just add it to `_JSON_VALUE_TYPES`).

The handler only activates when the value starts with `{` or `[`, so native tyro space-separated syntax (`--env-ratios 0.7 0.3`) continues to work exactly as before.

